### PR TITLE
Set multiple template-ref while running bonfire

### DIFF
--- a/_common_deploy_logic.sh
+++ b/_common_deploy_logic.sh
@@ -119,6 +119,21 @@ function transform_arg {
     echo "$options"
 }
 
+function transform_template_ref {
+    # transform set-template-ref to "$1" options for bonfire
+    options=""
+    option="$1"; shift;
+    components="$@"
+    for c in $components; do
+        options="$options $option $c=$GIT_COMMIT"
+    done
+    echo "$options"
+}
+
+if [ ! -z "$COMPONENT_NAME" ]; then
+    export TEMPLATE_REF_ARG=$(transform_template_ref --set-template-ref $COMPONENT_NAME)
+fi
+
 if [ ! -z "$COMPONENTS" ]; then
     export COMPONENTS_ARG=$(transform_arg --component $COMPONENTS)
 fi

--- a/deploy_ephemeral_env.sh
+++ b/deploy_ephemeral_env.sh
@@ -24,12 +24,12 @@ bonfire deploy \
     ${APP_NAME} \
     --source=appsre \
     --ref-env ${REF_ENV} \
-    --set-template-ref ${COMPONENT_NAME}=${GIT_COMMIT} \
     --set-image-tag ${IMAGE}=${IMAGE_TAG} \
     --namespace ${NAMESPACE} \
     --timeout ${DEPLOY_TIMEOUT} \
     --optional-deps-method ${OPTIONAL_DEPS_METHOD} \
     --frontends ${DEPLOY_FRONTENDS} \
+    ${TEMPLATE_REF_ARG} \
     ${COMPONENTS_ARG} \
     ${COMPONENTS_RESOURCES_ARG} \
     ${EXTRA_DEPLOY_ARGS}


### PR DESCRIPTION
We have multiple clowdapp files in [ros-ocp repo](https://github.com/RedHatInsights/ros-ocp-backend) and want that when PR check runs bonfire should refer both the clowdapp file from the PR commit. 