### PR TITLE
add default tag for specific cases

### DIFF
--- a/src/shared/image_builder_lib.sh
+++ b/src/shared/image_builder_lib.sh
@@ -112,8 +112,6 @@ cicd::image_builder::get_image_tag() {
 
   if [ -n "$default_tag" ]; then
     tag="${default_tag}"
-  else
-    tag=""
   fi
 
   if ! commit_hash=$(cicd::common::get_7_chars_commit_hash); then

--- a/src/shared/image_builder_lib.sh
+++ b/src/shared/image_builder_lib.sh
@@ -151,7 +151,11 @@ cicd::image_builder::get_build_id() {
 }
 
 cicd::image_builder::get_default_tag() {
-  local default_tag="$DEFAULT_TAG"
+  local default_tag
+
+  if [ -n "$DEFAULT_TAG" ]; then
+    default_tag="$DEFAULT_TAG"
+  fi
 
   echo -n "$default_tag"
 }

--- a/src/shared/image_builder_lib.sh
+++ b/src/shared/image_builder_lib.sh
@@ -108,6 +108,14 @@ cicd::image_builder::get_image_tag() {
 
   local commit_hash build_id tag
 
+  default_tag="$(cicd::image_builder::get_default_tag)"
+
+  if [ ! -z "$default_tag" ]; then
+    tag="${default_tag}"
+  else
+    tag=""
+  fi
+
   if ! commit_hash=$(cicd::common::get_7_chars_commit_hash); then
     cicd::err "Cannot retrieve commit hash!"
     return 1
@@ -115,10 +123,12 @@ cicd::image_builder::get_image_tag() {
 
   if cicd::image_builder::is_change_request_context; then
     build_id=$(cicd::image_builder::get_build_id)
-    tag="pr-${build_id}-${commit_hash}"
+    tag+="pr-${build_id}-${commit_hash}"
   else
-    tag="${commit_hash}"
+    tag+="${commit_hash}"
   fi
+
+  # prepend default tag
 
   echo -n "${tag}"
 }
@@ -138,6 +148,12 @@ cicd::image_builder::get_build_id() {
   fi
 
   echo -n "$build_id"
+}
+
+cicd::image_builder::get_default_tag() {
+  declare -a default_tag=("${DEFAULT_TAG}")
+
+  echo -n "${default_tag}"
 }
 
 cicd::image_builder::get_additional_tags() {

--- a/src/shared/image_builder_lib.sh
+++ b/src/shared/image_builder_lib.sh
@@ -110,7 +110,7 @@ cicd::image_builder::get_image_tag() {
 
   default_tag="$(cicd::image_builder::get_default_tag)"
 
-  if [ ! -z "$default_tag" ]; then
+  if [ -n "$default_tag" ]; then
     tag="${default_tag}"
   else
     tag=""
@@ -151,9 +151,9 @@ cicd::image_builder::get_build_id() {
 }
 
 cicd::image_builder::get_default_tag() {
-  declare -a default_tag=("${DEFAULT_TAG}")
+  local default_tag="$DEFAULT_TAG"
 
-  echo -n "${default_tag}"
+  echo -n "$default_tag"
 }
 
 cicd::image_builder::get_additional_tags() {

--- a/src/shared/image_builder_lib.sh
+++ b/src/shared/image_builder_lib.sh
@@ -111,7 +111,7 @@ cicd::image_builder::get_image_tag() {
   default_tag="$(cicd::image_builder::get_default_tag)"
 
   if [ -n "$default_tag" ]; then
-    tag="${default_tag}"
+    tag="${default_tag}-"
   fi
 
   if ! commit_hash=$(cicd::common::get_7_chars_commit_hash); then


### PR DESCRIPTION
the postgresql-rds repo builds several different images. One for each supported version of postgresql. During pr_checks, each build gets overwritten since additional_tags are ignored for change requests. This provides a "default_tag" which is prepended to the tag so we can differentiate between versions.