### PR TITLE
Support default tag updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ file [here](examples/unit_test_example.sh).
 The collection of helper libraries are expected to be loaded using the
 provided [src/bootstrap.sh](bootstrap) script.
 
-Currently, there are 2 supported libraries:
+Currently, there are 2 supported modules. To read more about what each of the modules provide,
+please read through the documents linked through the library IDs in the following table:
 
-| Library ID    | Description                                                                |
-|---------------|----------------------------------------------------------------------------|
-| container     | Provides wrapper functions for invoking container engine agnostic commands |
-| image_builder | Provides helper functions to simplify the image building process           |
+| Library ID                                            | Description                                                                |
+|-------------------------------------------------------|----------------------------------------------------------------------------|
+| [container](docs/cicd_tools/container_lib.md)         | Provides wrapper functions for invoking container engine agnostic commands |
+| [image_builder](docs/cicd_tools/image_builder_lib.md) | Provides helper functions to simplify the image building process           |
 
 ### How to use the helper libraries
 
@@ -45,14 +46,14 @@ centralized way. This should be helpful to reduce the amount of code needed to w
 operations in a pipeline for routine tasks, such as operating with containers or building container
 images.
 
-The [src/main.sh](main.sh) script is the main entrypoint and should be used to load the modules 
+The [src/main.sh](main.sh) script is the main entrypoint and should be used to load the modules
 included in this library. This script requires all the other scripts available in a local directory
 following the same structure in this repository.
 
 To use any of the provided libraries, you must source the [src/main.sh](main.sh) script
 and pass the unique library ID to be loaded as a parameter.
 
-There's two different approaches for loading these scripts, depending on if you're a contributor or 
+There's two different approaches for loading these scripts, depending on if you're a contributor or
 an end user.
 
 #### Contributing to the repository
@@ -63,7 +64,7 @@ contributing is to create a new fork and then open a pull request against the `m
 When working with a local copy of the repository, you should source the [src/main.sh](main.sh)
 script directly.
 
-#### Using the library from other scripts 
+#### Using the library from other scripts
 
 There is an existing helper script named [src/bootstrap.sh](bootstrap) to help with sourcing the
 [src/main.sh](main.sh) script if you're not contributing to this repo.

--- a/docs/cicd_tools/container_lib.md
+++ b/docs/cicd_tools/container_lib.md
@@ -1,7 +1,27 @@
-# Container lib module
+# Container module
 
 This module provides functions to help write container-engine agnostic Bash scripts. It does so by
 invoking one of the supported container engines found in the user's PATH.
+
+## Definition
+
+The module ID is `container`
+
+All functions exposed by this module will use the namespaced prefix:
+
+```
+cicd::container::
+```
+
+## Dependencies
+
+None
+
+### Public functions
+
+#### cicd::container::cmd
+
+Should be used instead of a container engine command to support container-engine agnostic commands (among the supported container engines)
 
 ## How to use
 

--- a/docs/cicd_tools/container_lib.md
+++ b/docs/cicd_tools/container_lib.md
@@ -1,3 +1,48 @@
-# Container lib
+# Container lib module
 
-TODO
+This module provides functions to help write container-engine agnostic Bash scripts. It does so by
+invoking one of the supported container engines found in the user's PATH.
+
+## How to use
+
+Use the `container` id to load the module
+
+```
+CICD_TOOLS_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main/src/bootstrap.sh"
+# shellcheck source=/dev/null
+source <(curl -sSL "$CICD_TOOLS_URL") container
+```
+
+This should load the function:
+
+```
+cicd::container::cmd
+```
+
+which serves as a wrapper to the container engine of choice. You should be able to safely replace
+your invocations to `docker` or `podman` commands with this function
+
+### Supported container engines
+
+We currently support `docker` and `podman`
+
+### Container engine detection and order choice
+
+The library favors `podman` in case both container engines are available in the user's PATH.
+
+### Override container engine selection
+
+If you want to force the library to stick to a preferred container engine, you can do so by setting
+the `CICD_TOOLS_CONTAINER_PREFER_ENGINE` to one of the supported container engines available *
+*before** loading the library.
+
+The container engine is selected when the library is loaded and is not possible to update it
+afterwards.
+
+```
+export CICD_TOOLS_CONTAINER_PREFER_ENGINE=docker
+```
+
+**Please note:** If you set your preference to be `docker` and the library detects that `docker` is
+actually mocked as a wrapper to `podman` the library will ignore the preference and will try to
+set `podman` as the selected container engine.

--- a/docs/cicd_tools/container_lib.md
+++ b/docs/cicd_tools/container_lib.md
@@ -1,0 +1,3 @@
+# Container lib
+
+TODO

--- a/docs/cicd_tools/image_builder.md
+++ b/docs/cicd_tools/image_builder.md
@@ -1,3 +1,48 @@
-# Image builder lib
+# Image builder module
 
-TODO
+This module provides functions to help write scripts simplify the image build process. It does so by
+invoking one of the supported container engines found in the user's PATH.
+
+## Definition
+
+The module ID is `image_builder`
+
+All functions exposed by this module will use the namespaced prefix:
+
+```
+cicd::image_builder::
+```
+
+### Public functions
+
+#### cicd::container::build_and_push
+
+This will build a container image and conditionally push it if not in a change request context using the provided configuration
+
+#### cicd::container::build
+
+This will build a container image using the provided configuration
+
+#### cicd::container::tag
+
+This function will create local tags using the provided configuration
+
+#### cicd::container::push
+
+This function will push all configured tags
+
+## How to use
+
+This module uses the following variables to configure the image building requirements:
+
+| Variable name | Description | Default value | Type | Mandatory |
+|CICD_TOOLS_IMAGE_BUILDER_IMAGE_NAME | The Image name to be used, in format: 'imageregistry/org/image_name' | `""` | string | Yes |
+|CICD_TOOLS_IMAGE_BUILDER_IMAGE_TAG | The main image tag to be used. If not provided the 7 first chars of the current repository's git commit hash will be used instead |`""` | string | No |
+|CICD_TOOLS_IMAGE_BUILDER_ADDITIONAL_TAGS | The additional tags (if any) to be created in array format: ("tag1" "tag2" "latest") | `()` | Array | No|
+|CICD_TOOLS_IMAGE_BUILDER_LABELS| The labels (if any) to add to the image being built in array format: ("label1=Value1" "label2=value2") | `()` | Array | No|
+|CICD_TOOLS_IMAGE_BUILDER_BUILD_ARGS| The build arguments to be provided when building the image (if any) in array format: ("buildarg1=Value1" "buildarg2=value2") | `()` | Array | No|
+|CICD_TOOLS_IMAGE_BUILDER_BUILD_CONTEXT| The build context path to use when building the image. | `.` | None | string | No|
+|CICD_TOOLS_IMAGE_BUILDER_CONTAINERFILE_PATH| The Containerfile path to use when building the image. | `Dockerfile` | None | string | No|
+|CICD_TOOLS_IMAGE_BUILDER_QUAY_EXPIRE_TIME| The expire time value to be set for Quay expires labels, used only in change request contexts. | `3d` | string | No|
+|CICD_TOOLS_IMAGE_BUILDER_QUAY_USER| The username to use when logging in to Quay. | `$QUAY_USER` | string | No|
+|CICD_TOOLS_IMAGE_BUILDER_QUAY_PASSWORD| The password to use when logging in to Quay. | `$QUAY_TOKEN` | string | No|

--- a/docs/cicd_tools/image_builder.md
+++ b/docs/cicd_tools/image_builder.md
@@ -1,0 +1,3 @@
+# Image builder lib
+
+TODO

--- a/docs/cicd_tools/image_builder.md
+++ b/docs/cicd_tools/image_builder.md
@@ -17,7 +17,8 @@ cicd::image_builder::
 
 #### cicd::container::build_and_push
 
-This will build a container image and conditionally push it if not in a change request context using the provided configuration
+This will build a container image and conditionally push it if not in a change request context using
+the provided configuration
 
 #### cicd::container::build
 
@@ -35,14 +36,54 @@ This function will push all configured tags
 
 This module uses the following variables to configure the image building requirements:
 
-| Variable name | Description | Default value | Type | Mandatory |
-|CICD_TOOLS_IMAGE_BUILDER_IMAGE_NAME | The Image name to be used, in format: 'imageregistry/org/image_name' | `""` | string | Yes |
-|CICD_TOOLS_IMAGE_BUILDER_IMAGE_TAG | The main image tag to be used. If not provided the 7 first chars of the current repository's git commit hash will be used instead |`""` | string | No |
-|CICD_TOOLS_IMAGE_BUILDER_ADDITIONAL_TAGS | The additional tags (if any) to be created in array format: ("tag1" "tag2" "latest") | `()` | Array | No|
-|CICD_TOOLS_IMAGE_BUILDER_LABELS| The labels (if any) to add to the image being built in array format: ("label1=Value1" "label2=value2") | `()` | Array | No|
-|CICD_TOOLS_IMAGE_BUILDER_BUILD_ARGS| The build arguments to be provided when building the image (if any) in array format: ("buildarg1=Value1" "buildarg2=value2") | `()` | Array | No|
-|CICD_TOOLS_IMAGE_BUILDER_BUILD_CONTEXT| The build context path to use when building the image. | `.` | None | string | No|
-|CICD_TOOLS_IMAGE_BUILDER_CONTAINERFILE_PATH| The Containerfile path to use when building the image. | `Dockerfile` | None | string | No|
-|CICD_TOOLS_IMAGE_BUILDER_QUAY_EXPIRE_TIME| The expire time value to be set for Quay expires labels, used only in change request contexts. | `3d` | string | No|
-|CICD_TOOLS_IMAGE_BUILDER_QUAY_USER| The username to use when logging in to Quay. | `$QUAY_USER` | string | No|
-|CICD_TOOLS_IMAGE_BUILDER_QUAY_PASSWORD| The password to use when logging in to Quay. | `$QUAY_TOKEN` | string | No|
+| Variable name                               | Description                                                                                                                       | Default value        | Type   | Mandatory |
+|---------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|----------------------|--------|-----------|
+| CICD_TOOLS_IMAGE_BUILDER_IMAGE_NAME         | The Image name to be used, in format: 'imageregistry/org/image_name'                                                              | `""`                 | string | Yes       |
+| CICD_TOOLS_IMAGE_BUILDER_IMAGE_TAG          | The main image tag to be used. If not provided the 7 first chars of the current repository's git commit hash will be used instead | `""`                 | string | No        |
+| CICD_TOOLS_IMAGE_BUILDER_ADDITIONAL_TAGS    | The additional tags (if any) to be created in array format: ("tag1" "tag2" "latest")                                              | `()`                 | Array  | No        |
+| CICD_TOOLS_IMAGE_BUILDER_LABELS             | The labels (if any) to add to the image being built in array format: ("label1=Value1" "label2=value2")                            | `()`                 | Array  | No        |
+| CICD_TOOLS_IMAGE_BUILDER_BUILD_ARGS         | The build arguments to be provided when building the image (if any) in array format: ("buildarg1=Value1" "buildarg2=value2")      | `()`                 | Array  | No        |
+| CICD_TOOLS_IMAGE_BUILDER_BUILD_CONTEXT      | The build context path to use when building the image.                                                                            | `.`                  | None   | string    | No|
+| CICD_TOOLS_IMAGE_BUILDER_CONTAINERFILE_PATH | The Containerfile path to use when building the image.                                                                            | `Dockerfile`         | None   | string    | No|
+| CICD_TOOLS_IMAGE_BUILDER_QUAY_EXPIRE_TIME   | The expire time value to be set for Quay expires labels, used only in change request contexts.                                    | `3d`                 | string | No        |
+| CICD_TOOLS_IMAGE_BUILDER_QUAY_USER          | The username to use when logging in to Quay.io                                                                                    | `$QUAY_USER`         | string | No        |
+| CICD_TOOLS_IMAGE_BUILDER_QUAY_PASSWORD      | The password to use when logging in to Quay.io                                                                                    | `$QUAY_TOKEN`        | string | No        |
+| CICD_TOOLS_IMAGE_BUILDER_REDHAT_USER        | The username to use when logging in to the Red Hat Registry                                                                       | `$RH_REGISTRY_USER`  | string | No        |
+| CICD_TOOLS_IMAGE_BUILDER_REDHAT_PASSWORD    | The password to use when logging in to the Red Hat Registry                                                                       | `$RH_REGISTRY_TOKEN` | string | No        |
+
+The only required variable is `CICD_TOOLS_IMAGE_BUILDER_IMAGE_NAME`, the rest of them are optional
+and should not be needed for the majority of use cases as the provided default values should be
+enough.
+
+It is important to consider that the behavior of the different image builder functions may be
+affected by the context where it runs.
+The context include a CI context (for example, while running in a pipeline), and running in a Change
+Request (a Pull Request pipeline for a project hosted in Github or a Merge Request pipeline for a
+project hosted in Gitlab).
+
+## Expected Image tags based on the environment
+
+The following table has examples of the different combinations of the variables and tags that are
+expected to be created, considering if:
+
+- In a Change Request context (A pull request or Merge request pipeline)
+- A default Image Tag is specified
+- Additional tags are specified
+
+| CR context | Image tag   | Additional tags     | Tags created                                                           |
+|------------|-------------|---------------------|------------------------------------------------------------------------|
+| NO         | N/A         | N/A                 | `${GIT_SHA}`                                                           |
+| NO         | N/A         | `("tag1" "latest")` | `${GIT_SHA} tag1 latest`                                               |
+| NO         | awesome-tag | N/A                 | `awesome-tag`                                                          |
+| NO         | awesome-tag | `("tag1" "latest")` | `awesome-tag tag1 latest`                                              |
+| YES        | N/A         | N/A                 | `pr-${BUILD_ID}-${GIT_SHA}`                                            |
+| YES        | N/A         | `("tag1" "latest")` | `pr-${BUILD_ID}-GIT_SHA pr-${BUILD_ID}-tag1 pr-${BUILD_ID}-latest`     |
+| YES        | awesome-tag | N/A                 | `pr-${BUILD_ID}-awesome-tag`                                           |
+| YES        | awesome-tag | `("tag1" "latest")` | `pr-${BUILD_ID}-awesome-tag pr-${BUILD_ID}-tag1 pr-${BUILD_ID}-latest` |
+
+**Important:** This module will **only** try to authenticate against either registry if it finds the
+variables present in the environment. In addition, in a CI context the `DOCKER_CONFIG` file will be
+recreated using a temporary file, so it is expected that the required registry credentials are
+provided as environment variables.
+
+

--- a/src/shared/image_builder_lib.sh
+++ b/src/shared/image_builder_lib.sh
@@ -106,18 +106,39 @@ cicd::image_builder::_get_image_name() {
 
 cicd::image_builder::get_image_tag() {
 
-  local commit_hash build_id tag
+  local base_tag="${CICD_TOOLS_IMAGE_BUILDER_IMAGE_TAG:-$IMAGE_TAG}"
+
+  if [[ -z "$base_tag" ]]; then
+    base_tag=$(cicd::image_builder::get_commit_based_image_tag)
+  fi
+
+  cicd::image_builder::_get_context_based_image_tag "$base_tag"
+
+  echo -n "${tag}"
+}
+
+cicd::image_builder::get_commit_based_image_tag() {
+
+  local commit_hash
 
   if ! commit_hash=$(cicd::common::get_7_chars_commit_hash); then
     cicd::err "Cannot retrieve commit hash!"
     return 1
   fi
 
+  echo -n "$commit_hash"
+}
+
+cicd::image_builder::_get_context_based_image_tag() {
+
+  local base_tag="$1"
+  local tag
+
   if cicd::image_builder::is_change_request_context; then
     build_id=$(cicd::image_builder::get_build_id)
-    tag="pr-${build_id}-${commit_hash}"
+    tag="pr-${build_id}-${base_tag}"
   else
-    tag="${commit_hash}"
+    tag="${base_tag}"
   fi
 
   echo -n "${tag}"

--- a/src/shared/image_builder_lib.sh
+++ b/src/shared/image_builder_lib.sh
@@ -167,7 +167,7 @@ cicd::image_builder::get_additional_tags() {
   fi
 
   for tag in "${configured_tags[@]}"; do
-    additional_tags+=("$(cicd::image_builder::_get_context_based_image_tag $tag)")
+    additional_tags+=("$(cicd::image_builder::_get_context_based_image_tag "$tag")")
   done
 
   echo -n "${additional_tags[@]}"

--- a/test/shared_image_builder_lib.bats
+++ b/test/shared_image_builder_lib.bats
@@ -415,7 +415,7 @@ setup() {
     assert_output --partial "push someimage:tag2"
 }
 
-@test "push only one image on change-request-context" {
+@test "push all image tags with context prefix on change-request-context" {
 
     # git mock
     git() {
@@ -436,8 +436,8 @@ setup() {
 
     assert_success
     assert_output --partial "push someimage:pr-123-abcdef1"
-    refute_output --partial "push someimage:tag1"
-    refute_output --partial "push someimage:tag2"
+    assert_output --regexp "push someimage:pr-123-tag1"
+    assert_output --regexp "push someimage:pr-123-tag2"
 }
 
 @test "push error is caught" {
@@ -510,18 +510,22 @@ setup() {
     source main.sh image_builder
 
     IMAGE_NAME="someimage"
-    ADDITIONAL_TAGS=("target1")
+    ADDITIONAL_TAGS=("target1" "target2")
     CONTAINERFILE_PATH='test/data/Containerfile.test'
 
     run cicd::image_builder::build_and_push
 
     assert_success
-    assert_output --regexp "^build.*?-t someimage:source -t someimage:target1"
-    assert_output --partial "push"
+    assert_output --regexp "^build.*?-t someimage:source"
+    assert_output --regexp "^build.*?-t someimage:target1"
+    assert_output --regexp "^build.*?-t someimage:target2"
+    assert_output --partial "push someimage:source"
+    assert_output --partial "push someimage:target1"
+    assert_output --partial "push someimage:target2"
 }
 
 
-@test "build_and_push pushes only default tag if on change request context" {
+@test "build_and_push pushes all tags with context prefix if on change request context" {
 
     # git mock
     git() {
@@ -536,17 +540,16 @@ setup() {
 
     ghprbPullId='123'
     IMAGE_NAME="someimage"
-    ADDITIONAL_TAGS=("target1")
+    ADDITIONAL_TAGS=("target1" "target2")
     CONTAINERFILE_PATH='test/data/Containerfile.test'
 
     run cicd::image_builder::build_and_push
 
     assert_success
     assert_output --regexp "^build.*?-t someimage:pr-123-source"
-    refute_output --regexp "^build.*?-t someimage:target1"
     assert_output --regexp "^build.*?--label quay.expires-after"
-    assert_output --regexp "^build.*?-t someimage:pr-123-source"
-    refute_output --regexp "^build.*?-t someimage:target1"
+    assert_output --regexp "^build.*?-t someimage:pr-123-target1"
+    assert_output --regexp "^build.*?-t someimage:pr-123-target2"
 }
 
 @test "Image build setup doesn't force fresh DOCKER_CONF if not in CI context" {
@@ -566,7 +569,6 @@ setup() {
     source main.sh image_builder
     assert [ -n "$DOCKER_CONFIG" ]
     assert [ -w "${DOCKER_CONFIG}/config.json" ]
-
 }
 
 @test "Default image tag is configured if none set" {
@@ -578,16 +580,13 @@ setup() {
     source main.sh image_builder
 
     expected_tag="abcdef1"
-    actual_tag="$(cicd::image_builder::get_image_tag)"
-
-    assert [ "$expected_tag" == "$actual_tag" ]
+    run cicd::image_builder::get_image_tag
+    assert_output "$expected_tag"
 
     export CICD_TOOLS_IMAGE_BUILDER_IMAGE_TAG='some-cool-tag'
-
     expected_tag="$CICD_TOOLS_IMAGE_BUILDER_IMAGE_TAG"
-    actual_tag="$(cicd::image_builder::get_image_tag)"
-
-    assert [ "$expected_tag" == "$actual_tag" ]
+    run cicd::image_builder::get_image_tag
+    assert_output "$expected_tag"
 }
 
 @test "Build custom tag support" {
@@ -604,9 +603,9 @@ setup() {
     export CONTAINERFILE_PATH='test/data/Containerfile.test'
 
     expected_tag="$CICD_TOOLS_IMAGE_BUILDER_IMAGE_TAG"
-    actual_tag="$(cicd::image_builder::get_image_tag)"
+    run cicd::image_builder::get_image_tag
 
-    assert [ "$expected_tag" == "$actual_tag" ]
+    assert_output "$expected_tag"
 
     run cicd::image_builder::build
 
@@ -617,4 +616,49 @@ setup() {
 
     assert_output --regexp "^build.*-t foobar:custom-tag2"
     refute_output --regexp "^build.*-t foobar:custom-tag1"
+}
+
+@test "Custom tag support for change request context" {
+
+    # podman mock
+    podman() {
+        echo "$@"
+    }
+
+    source main.sh image_builder
+
+    export CICD_TOOLS_IMAGE_BUILDER_IMAGE_TAG='custom-tag1'
+    export ghprbPullId=123
+
+    expected_tag="pr-123-$CICD_TOOLS_IMAGE_BUILDER_IMAGE_TAG"
+    run cicd::image_builder::get_image_tag
+
+    assert_output "$expected_tag"
+}
+
+@test "Build additional tags in change request context" {
+
+    # podman mock
+    podman() {
+        echo "$@"
+    }
+
+    source main.sh image_builder
+
+    export CICD_TOOLS_IMAGE_BUILDER_IMAGE_NAME='foobar'
+    export CICD_TOOLS_IMAGE_BUILDER_IMAGE_TAG='custom-tag1'
+    export CONTAINERFILE_PATH='test/data/Containerfile.test'
+    export CICD_TOOLS_IMAGE_BUILDER_ADDITIONAL_TAGS=("extra1" "extra2")
+    export ghprbPullId=123
+
+    expected_tag="pr-123-$CICD_TOOLS_IMAGE_BUILDER_IMAGE_TAG"
+    run cicd::image_builder::get_image_tag
+
+    assert_output "$expected_tag"
+
+    run cicd::image_builder::build
+
+    assert_output --regexp "^build.*-t foobar:pr-123-custom-tag1"
+    assert_output --regexp "^build.*-t foobar:pr-123-extra1"
+    assert_output --regexp "^build.*-t foobar:pr-123-extra2"
 }


### PR DESCRIPTION
This changes the current behavior to:
- Always push and create all the tags (previously on CI context it would only push / create the main tag)
- Override the default "git hash tag" with a user-chosen tag. 