### PR TITLE
Add the option to change bonfire reservation duration

### DIFF
--- a/deploy_ephemeral_env.sh
+++ b/deploy_ephemeral_env.sh
@@ -6,6 +6,9 @@ source ${CICD_ROOT}/_common_deploy_logic.sh
 # Caller can specify the type of pool to use
 : ${NAMESPACE_POOL:="default"}
 
+# Caller can specify the reservation duration (default: 1h)
+: ${RESERVE_DURATION:="1h"}
+
 # Caller can alter the default dependency fetching method if desired
 : ${OPTIONAL_DEPS_METHOD:="hybrid"}
 
@@ -16,7 +19,7 @@ source ${CICD_ROOT}/_common_deploy_logic.sh
 # -> use this PR as the template ref when downloading configurations for this component
 # -> use this PR's newly built image in the deployed configurations
 set -x
-export NAMESPACE=$(bonfire namespace reserve --pool ${NAMESPACE_POOL})
+export NAMESPACE=$(bonfire namespace reserve --pool ${NAMESPACE_POOL} --duration ${RESERVE_DURATION})
 SMOKE_NAMESPACE=$NAMESPACE  # track which namespace was used here for 'teardown' in common_deploy_logic
 
 


### PR DESCRIPTION
Sometimes our `pr_check` can take over an hour so we need the option to reserve the namespace for longer.