### PR TITLE
Revert "Ensure JUnit tests pass"

### DIFF
--- a/cji_smoke_test.sh
+++ b/cji_smoke_test.sh
@@ -191,33 +191,5 @@ if [ "$MINIO_SUCCESS" = false ]; then
     exit 1
 fi
 
-echo "checking if files exist"
-
-JUNIT_SEQUENTIAL_OUTPUTS=(
-    "iqe-${CJI_NAME}-sequential.log"
-    "junit-${CJI_NAME}-sequential.xml"
-)
-
-for file in "${JUNIT_SEQUENTIAL_OUTPUTS[@]}"; do
-  if [ ! -e "$ARTIFACTS_DIR/$file" ]; then
-    echo "The file $file does not exist. CJI Test(s) may have failed."
-    exit 1
-  fi
-done
-
-if [ "$IQE_PARALLEL_ENABLED" = "true" ]; then
-    JUNIT_PARALLEL_OUTPUTS=(
-        "iqe-${CJI_NAME}-parallel.log"
-        "junit-${CJI_NAME}-parallel.xml"
-    )
-
-    for file in "${JUNIT_SEQUENTIAL_OUTPUTS[@]}"; do
-    if [ ! -e "$ARTIFACTS_DIR/$file" ]; then
-        echo "The file $file does not exist. CJI Test(s) may have failed."
-        exit 1
-    fi
-    done
-fi
-
 echo "copied artifacts from iqe pod: "
 ls -l $ARTIFACTS_DIR


### PR DESCRIPTION
Reverts RedHatInsights/cicd-tools#30

reverting because [iqe_runner.sh](https://github.com/RedHatInsights/cicd-tools/blob/main/iqe_pod/iqe_runner.sh) uses $plugin to construct the filename but the [cji_smoke_test.sh](https://github.com/RedHatInsights/cicd-tools/blob/main/cji_smoke_test.sh) relies on $CJI_NAME and that doesn't always match