### PR TITLE
Rename artifacts to IQE_PLUGINS

### DIFF
--- a/cji_smoke_test.sh
+++ b/cji_smoke_test.sh
@@ -194,8 +194,8 @@ fi
 echo "checking if files exist"
 
 JUNIT_SEQUENTIAL_OUTPUTS=(
-    "iqe-${CJI_NAME}-sequential.log"
-    "junit-${CJI_NAME}-sequential.xml"
+    "iqe-${IQE_PLUGINS}-sequential.log"
+    "junit-${IQE_PLUGINS}-sequential.xml"
 )
 
 for file in "${JUNIT_SEQUENTIAL_OUTPUTS[@]}"; do
@@ -207,8 +207,8 @@ done
 
 if [ "$IQE_PARALLEL_ENABLED" = "true" ]; then
     JUNIT_PARALLEL_OUTPUTS=(
-        "iqe-${CJI_NAME}-parallel.log"
-        "junit-${CJI_NAME}-parallel.xml"
+        "iqe-${IQE_PLUGINS}-parallel.log"
+        "junit-${IQE_PLUGINS}-parallel.xml"
     )
 
     for file in "${JUNIT_SEQUENTIAL_OUTPUTS[@]}"; do


### PR DESCRIPTION
Rename artifacts to IQE_PLUGINS, because those are the artifacts generated in iqe-runner