### PR TITLE
Multiarch support

### DIFF
--- a/docs/cicd_tools/image_builder.md
+++ b/docs/cicd_tools/image_builder.md
@@ -226,6 +226,18 @@ The context include a CI context (for example, while running in a pipeline), and
 Request (a Pull Request pipeline for a project hosted in Github or a Merge Request pipeline for a
 project hosted in Gitlab).
 
+## CICD_IMAGE_BUILDER_MULTIARCH
+
+Type: "boolean", Default value: "false"
+
+If set to true, the image will be built for multiple architectures. The default value is false.
+
+## CICD_IMAGE_BUILDER_BUILDX_BUILDER
+
+Type: "string", Default value: "multiarchbuilder"
+
+The name of the buildx builder to use when building multiarch images. The default value is "multiarchbuilder".
+
 ## Expected Image tags based on the environment
 
 The following table has examples of the different combinations of the variables and tags that are

--- a/src/shared/container.sh
+++ b/src/shared/container.sh
@@ -21,6 +21,21 @@ cicd::container::cmd() {
   "$CICD_CONTAINER_ENGINE" "$@"
 }
 
+cicd::container::_get_buildx_available() {
+
+  local buildx_available=1
+
+  if cicd::container::_container_engine_available 'docker'; then
+    if docker buildx &> /dev/null; then
+      buildx_available=0
+    else
+      cicd::log::info "WARNING: docker buildx not available."
+    fi
+  fi
+
+  return "$buildx_available"
+}
+
 cicd::container::_set_container_engine_cmd() {
 
   if cicd::container::_preferred_container_engine_available; then

--- a/src/shared/image_builder.sh
+++ b/src/shared/image_builder.sh
@@ -99,6 +99,7 @@ cicd::image_builder::build() {
     fi
   fi
 
+  # Restore the docker config
   export DOCKER_CONFIG="$docker_config_cache"
   # Standard build - used if multiarch is not true or if buildx is not available
   if ! cicd::container::cmd build "${build_params[@]}"; then

--- a/src/shared/image_builder.sh
+++ b/src/shared/image_builder.sh
@@ -86,7 +86,7 @@ cicd::image_builder::build() {
     if cicd::container::_get_buildx_available && cicd::image_builder::_buildx_builder_available && ! cicd::image_builder::is_change_request_context; then
       # buildx is only supported with docker
       # so we need to set the container engine to docker
-      CICD_CONTAINER_PREFER_ENGINE="docker"
+      export CICD_CONTAINER_PREFER_ENGINE="docker"
       cicd::container::_set_container_engine_cmd
       build_params+=('--platform linux/amd64,linux/arm64')
       if ! cicd::container::cmd buildx build "${build_params[@]}"; then

--- a/src/shared/image_builder.sh
+++ b/src/shared/image_builder.sh
@@ -99,8 +99,11 @@ cicd::image_builder::build() {
     fi
   fi
 
-  # Restore the docker config
-  export DOCKER_CONFIG="$docker_config_cache"
+  # Restore the docker config if required
+  if [ -z "$DOCKER_CONFIG" ] && [ -n "$docker_config_cache" ]; then
+      export DOCKER_CONFIG="$docker_config_cache"
+  fi
+
   # Standard build - used if multiarch is not true or if buildx is not available
   if ! cicd::container::cmd build "${build_params[@]}"; then
     cicd::log::err "Error building image"

--- a/src/shared/image_builder.sh
+++ b/src/shared/image_builder.sh
@@ -83,7 +83,7 @@ cicd::image_builder::build() {
   if [[ "$multiarch" = true ]]; then
     # if buildx and the specified builder are available, use it
     # if not, fall back to standard build
-    if cicd::container::_get_buildx_available && cicd::image_builder::_buildx_builder_available && !cicd::image_builder::is_change_request_context;; then
+    if cicd::container::_get_buildx_available && cicd::image_builder::_buildx_builder_available && ! cicd::image_builder::is_change_request_context; then
       # buildx is only supported with docker
       # so we need to set the container engine to docker
       CICD_CONTAINER_PREFER_ENGINE="docker"


### PR DESCRIPTION
This patch adds multiarch support to the image_builder, with a lot of checks and conditionality to ensure that we use sane defaults, multiarch builds are only executed under the right contexts, and we always fallback to the standard single arch build if something goes wrong.

usage:
```
export CICD_IMAGE_BUILDER_MULTIARCH=true
cicd::image_builder::build
```

advanced usage:
```
export CICD_IMAGE_BUILDER_MULTIARCH=true
export CICD_IMAGE_BUILDER_BUILDX_BUILDER='multiarchbuilder'
cicd::image_builder::build
```

The checks and conditions are:
* if this is a PR check we will skip doing a multiarch build and just do a standard build
* if the container command docker is unavailable we will just do a standard build
* if the buildx docker extension isn't installed we will just do a standard build
* if buildx builder doesn't exist we will just do a standard build

Gotchas:
* We have to switch from using the `DOCKER_CONFIG` created by the library to the global context while using buildx. This is because the context created by the library doesn't have the builder in it. The builder has to be created by a privileged user and thus can't be created at runtime. The builder `multiarchbuilder` is in the global context and provided by App SRE on our jenkins nodes
* I don't know how to write tests for this library so there are no tests for the new functionality.