### PR TITLE
Use a job tmp dir instead of WORKSPACE

### DIFF
--- a/_common_deploy_logic.sh
+++ b/_common_deploy_logic.sh
@@ -16,7 +16,7 @@
 
 add_cicd_bin_to_path
 
-# this trap replaces 'job_cleanup' set in bootstrap.sh, but we'll re-set it at the end of 'teardown'
+# this replaces 'job_cleanup' set in bootstrap.sh, so we make sure to run that at the end of 'teardown'
 trap_proxy teardown EXIT ERR SIGINT SIGTERM
 
 set -e
@@ -63,12 +63,13 @@ function collect_k8s_artifacts() {
 }
 
 function teardown {
+    [ "$TEARDOWN_RAN" -ne "0" ] && return
+
     local CAPTURED_SIGNAL="$1"
 
     add_cicd_bin_to_path
 
     set +x
-    [ "$TEARDOWN_RAN" -ne "0" ] && return
     echo "------------------------"
     echo "----- TEARING DOWN -----"
     echo "------------------------"
@@ -99,10 +100,9 @@ function teardown {
         set -e
     done
 
-    # make sure cleanup gets run at final exit
-    trap job_cleanup EXIT ERR SIGINT SIGTERM
-
     TEARDOWN_RAN=1
+
+    job_cleanup $CAPTURED_SIGNAL
 }
 
 function transform_arg {

--- a/_common_deploy_logic.sh
+++ b/_common_deploy_logic.sh
@@ -16,14 +16,7 @@
 
 add_cicd_bin_to_path
 
-function trap_proxy {
-    # https://stackoverflow.com/questions/9256644/identifying-received-signal-name-in-bash
-    func="$1"; shift
-    for sig; do
-        trap "$func $sig" "$sig"
-    done
-}
-
+# this trap replaces 'cleanup' set in bootstrap.sh, but we'll re-set it at the end of 'teardown'
 trap_proxy teardown EXIT ERR SIGINT SIGTERM
 
 set -e
@@ -105,6 +98,10 @@ function teardown {
         fi
         set -e
     done
+
+    # make sure cleanup gets run at final exit
+    trap job_cleanup EXIT ERR SIGINT SIGTERM
+
     TEARDOWN_RAN=1
 }
 

--- a/_common_deploy_logic.sh
+++ b/_common_deploy_logic.sh
@@ -16,7 +16,7 @@
 
 add_cicd_bin_to_path
 
-# this trap replaces 'cleanup' set in bootstrap.sh, but we'll re-set it at the end of 'teardown'
+# this trap replaces 'job_cleanup' set in bootstrap.sh, but we'll re-set it at the end of 'teardown'
 trap_proxy teardown EXIT ERR SIGINT SIGTERM
 
 set -e

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,14 +25,14 @@ function trap_proxy() {
 export TMP_JOB_DIR=$(mktemp -d -t "jenkins-${JOB_NAME}-${BUILD_NUMBER}-XXXXXX")
 echo "job tmp dir location: $TMP_JOB_DIR"
 
-function cleanup() {
+function job_cleanup() {
     local CAPTURED_SIGNAL="$1"
     echo "triggering job cleanup due to signal: $CAPTURED_SIGNAL"
 
     rm -fr $TMP_JOB_DIR
 }
 
-trap_proxy cleanup EXIT ERR SIGINT SIGTERM
+trap_proxy job_cleanup EXIT ERR SIGINT SIGTERM
 
 export APP_ROOT=$(pwd)
 export WORKSPACE=${WORKSPACE:-$APP_ROOT}  # if running in jenkins, use the build's workspace

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,9 +13,30 @@ if test -f unit_test.sh; then
   fi
 fi
 
+function trap_proxy() {
+    # https://stackoverflow.com/questions/9256644/identifying-received-signal-name-in-bash
+    func="$1"; shift
+    for sig; do
+        trap "$func $sig" "$sig"
+    done
+}
+
+# Create tmp dir to store data in during job run (do NOT store in $WORKSPACE)
+export TMP_JOB_DIR=$(mktemp -d -t "jenkins-${JOB_NAME}-${BUILD_NUMBER}-XXXXXX")
+echo "job tmp dir location: $TMP_JOB_DIR"
+
+function cleanup() {
+    local CAPTURED_SIGNAL="$1"
+    echo "triggering job cleanup due to signal: $CAPTURED_SIGNAL"
+
+    rm -fr $TMP_JOB_DIR
+}
+
+trap_proxy cleanup EXIT ERR SIGINT SIGTERM
+
 export APP_ROOT=$(pwd)
 export WORKSPACE=${WORKSPACE:-$APP_ROOT}  # if running in jenkins, use the build's workspace
-export BONFIRE_ROOT=${WORKSPACE}/.bonfire
+export BONFIRE_ROOT=${TMP_JOB_DIR}/.bonfire
 export CICD_ROOT=${BONFIRE_ROOT}
 export IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 export BONFIRE_BOT="true"
@@ -30,15 +51,14 @@ if [[ -z "${AVAILABLE_CLUSTERS[*]}" ]]; then
 fi
 
 set -x
+
 # Set up docker cfg
-export DOCKER_CONFIG="${WORKSPACE}/.docker"
-rm -rf "$DOCKER_CONFIG"
+export DOCKER_CONFIG="${TMP_JOB_DIR}/.docker"
 mkdir "$DOCKER_CONFIG"
 
 # Set up kube cfg
-export KUBECONFIG_DIR="${WORKSPACE}/.kube"
+export KUBECONFIG_DIR="${TMP_JOB_DIR}/.kube"
 export KUBECONFIG="${KUBECONFIG_DIR}/config"
-rm -rf "$KUBECONFIG_DIR"
 mkdir "$KUBECONFIG_DIR"
 
 set +x


### PR DESCRIPTION
Store .docker, .kube, and .bonfire in a tmp dir so they are not part of the content in $WORKSPACE