### PR TITLE
Remove trap_proxy

### DIFF
--- a/_common_deploy_logic.sh
+++ b/_common_deploy_logic.sh
@@ -17,7 +17,7 @@
 add_cicd_bin_to_path
 
 # this replaces 'job_cleanup' set in bootstrap.sh, so we make sure to run that at the end of 'teardown'
-trap_proxy teardown EXIT ERR SIGINT SIGTERM
+trap teardown EXIT ERR SIGINT SIGTERM
 
 set -e
 
@@ -65,8 +65,6 @@ function collect_k8s_artifacts() {
 function teardown {
     [ "$TEARDOWN_RAN" -ne "0" ] && return
 
-    local CAPTURED_SIGNAL="$1"
-
     add_cicd_bin_to_path
 
     set +x
@@ -74,8 +72,6 @@ function teardown {
     echo "----- TEARING DOWN -----"
     echo "------------------------"
     local ns
-
-    echo "Tear down operation triggered by signal: $CAPTURED_SIGNAL"
 
     # run teardown on all namespaces possibly reserved in this run
     RESERVED_NAMESPACES=("${NAMESPACE}" "${DB_NAMESPACE}" "${SMOKE_NAMESPACE}")
@@ -100,9 +96,9 @@ function teardown {
         set -e
     done
 
-    TEARDOWN_RAN=1
+    job_cleanup
 
-    job_cleanup $CAPTURED_SIGNAL
+    TEARDOWN_RAN=1
 }
 
 function transform_arg {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,26 +13,16 @@ if test -f unit_test.sh; then
   fi
 fi
 
-function trap_proxy() {
-    # https://stackoverflow.com/questions/9256644/identifying-received-signal-name-in-bash
-    func="$1"; shift
-    for sig; do
-        trap "$func $sig" "$sig"
-    done
-}
-
 # Create tmp dir to store data in during job run (do NOT store in $WORKSPACE)
 export TMP_JOB_DIR=$(mktemp -d -p "$HOME" -t "jenkins-${JOB_NAME}-${BUILD_NUMBER}-XXXXXX")
 echo "job tmp dir location: $TMP_JOB_DIR"
 
 function job_cleanup() {
-    local CAPTURED_SIGNAL="$1"
-    echo "triggering job cleanup due to signal: $CAPTURED_SIGNAL"
-
+    echo "in job_cleanup handler, removing tmp dir: $TMP_JOB_DIR"
     rm -fr $TMP_JOB_DIR
 }
 
-trap_proxy job_cleanup EXIT ERR SIGINT SIGTERM
+trap job_cleanup EXIT ERR SIGINT SIGTERM
 
 export APP_ROOT=$(pwd)
 export WORKSPACE=${WORKSPACE:-$APP_ROOT}  # if running in jenkins, use the build's workspace


### PR DESCRIPTION
I suspect trap_proxy is causing some unexpected behavior when it comes to "overwriting" a trap... currently we call: 
* `trap_proxy job_cleanup EXIT ERR SIGINT SIGTERM` in bootstrap.sh
* and `trap_proxy teardown EXIT ERR SIGINT SIGTERM` in _common_deploy_logic.sh

but in Jenkins we see evidence of the job_cleanup running *before* the teardown runs:
```
+++ job_cleanup ERR
+++ local CAPTURED_SIGNAL=ERR
+++ echo 'triggering job cleanup due to signal: ERR'
triggering job cleanup due to signal: ERR
+++ rm -fr /var/lib/jenkins/jenkins-insights-platform-advisor-backend-smoke-test-master-19085-dHySbX
+ teardown EXIT
+ '[' 0 -ne 0 ']'
+ local CAPTURED_SIGNAL=EXIT
```

This doesn't make sense ... my understanding is that we should be re-setting the trap handler for all of these signals -- I would not expect `job_cleanup` to ever get invoked like this. `teardown` should be getting invoked on that first ERR signal.