### PR TITLE
feat(tests): prepare tests for adding Dockerfile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '14'
-      - run: npm install -g bats
       - name: BATS tests
-        run: bats test
+        run: ./test/bats/bin/bats test
       - name: E2E tests
         run: |
           for test_script in test/e2e/test_e2e_load_library*; do
@@ -42,10 +38,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '14'
-      - run: npm install -g bats
       - run: ./test/generate_coverage.sh
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "test/test_helper/bats-assert"]
 	path = test/test_helper/bats-assert
 	url = https://github.com/bats-core/bats-assert.git
+[submodule "test/bats"]
+	path = test/bats
+	url = https://github.com/bats-core/bats-core.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+Dummy Dockerfile

--- a/README.md
+++ b/README.md
@@ -26,6 +26,30 @@ file [here](examples/unit_test_example.sh).
 | smoke_test.sh           | **DEPRECATED**, use [cji_smoke_test.sh](cji_smoke_test.sh)                                                                                                                                                                                                       |
 | iqe_pod                 | **DEPRECATED**, use [cji_smoke_test.sh](cji_smoke_test.sh)                                                                                                                                                                                                       |
 
+## Running the Bash script library tests
+
+The Bash script library uses [BATS](https://bats-core.readthedocs.io/en/stable/) for its unit tests. 
+
+In order to run the tests, you need to have fetched all the git submodules (BATS and the test_helpers are provided as git submodules). 
+
+You can do this at clone time:
+
+```shell
+# git clone --recurse-submodules https://github.com/RedHatInsights/cicd-tools
+```
+
+or if you already cloned it, but you don't have fetched the submodules you can do that with:
+
+```shell
+# git submodule update --init
+```
+
+you can then run BATS from the provided git submodule: 
+
+```shell
+# ./test/bats/bin/bats test
+```
+
 ## Bash script library usage
 
 The collection of helper libraries are expected to be loaded using the

--- a/test/generate_coverage.sh
+++ b/test/generate_coverage.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 COVERAGE_DIRECTORY="$PWD/coverage"
-BATS_CMD='bats'
+BATS_CMD='./test/bats/bin/bats'
 TESTS_PATH="${1:-test}"
 IGNORE_TAGS='!no-kcov'
 KCOV_CMD='kcov'

--- a/test/shared_image_builder.bats
+++ b/test/shared_image_builder.bats
@@ -2,6 +2,21 @@
 setup() {
     load "test_helper/common-setup"
     _common_setup
+
+    CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH="Dockerfile"
+    if [[ -r "$CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH" ]]; then
+       mv "$CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH" "${CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH}.tmp"
+    fi
+
+    touch foo
+}
+
+teardown() {
+
+    if [[ -r "${CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH}.tmp" ]]; then
+       mv "${CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH}.tmp" "$CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH"
+    fi
+    touch bar
 }
 
 
@@ -123,14 +138,15 @@ setup() {
 
     source load_module.sh image_builder
 
-    EXPECTED_CONTAINERFILE_PATH='Dockerfile'
     IMAGE_NAME='quay.io/foo/bar'
 
-    refute [ -r "$EXPECTED_CONTAINERFILE_PATH" ]
+    refute [ -r "$CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH" ]
+
     run ! cicd::image_builder::build
     assert_failure
-    assert_output --regexp "$EXPECTED_CONTAINERFILE_PATH.*does not exist"
+    assert_output --regexp "$CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH.*does not exist"
     refute_output --regexp "build"
+
 }
 
 @test "Image build fails if no image name is defined" {
@@ -188,12 +204,11 @@ setup() {
 
     source load_module.sh image_builder
 
-    EXPECTED_CONTAINERFILE_PATH='Dockerfile'
     IMAGE_NAME='quay.io/foo/bar'
 
-    touch "${EXPECTED_CONTAINERFILE_PATH}"
+    touch "$CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH"
     run cicd::image_builder::build
-    rm "${EXPECTED_CONTAINERFILE_PATH}"
+    rm "$CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH"
 
     assert_success
     assert_output --regexp "^build"

--- a/test/shared_image_builder.bats
+++ b/test/shared_image_builder.bats
@@ -7,8 +7,6 @@ setup() {
     if [[ -r "$CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH" ]]; then
        mv "$CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH" "${CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH}.tmp"
     fi
-
-    touch foo
 }
 
 teardown() {
@@ -16,7 +14,6 @@ teardown() {
     if [[ -r "${CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH}.tmp" ]]; then
        mv "${CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH}.tmp" "$CICD_IMAGE_BUILDER_DEFAULT_CONTAINERFILE_PATH"
     fi
-    touch bar
 }
 
 


### PR DESCRIPTION
- Updates tests for the eventual addition of a Dockerfile to the repo. The tests assumed no Dockerfile existed but this would break them should a Dockerfile is added
- Adds `bats` as a submodule for locally running tests

also unblocks https://github.com/gbenhaim/cicd-tools/pull/15