### PR TITLE
refactor(ci): refactor bootstrap paths

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,16 +24,14 @@ function job_cleanup() {
 
 trap job_cleanup EXIT ERR SIGINT SIGTERM
 
-export APP_ROOT=$(pwd)
-export WORKSPACE=${WORKSPACE:-$APP_ROOT}  # if running in jenkins, use the build's workspace
-export BONFIRE_ROOT=${TMP_JOB_DIR}/.bonfire
-export CICD_ROOT=${BONFIRE_ROOT}
+CICD_TOOLS_DIR=$TMP_JOB_DIR/.cicd_tools
+export APP_ROOT=${WORKSPACE:-$(pwd)}
 export IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 export BONFIRE_BOT="true"
 export BONFIRE_NS_REQUESTER="${JOB_NAME}-${BUILD_NUMBER}"
 # which branch to fetch cicd scripts from in bonfire repo
-export BONFIRE_REPO_BRANCH="${BONFIRE_REPO_BRANCH:-main}"
-export BONFIRE_REPO_ORG="${BONFIRE_REPO_ORG:-RedHatInsights}"
+export CICD_REPO_BRANCH="${CICD_REPO_BRANCH:-main}"
+export CICD_REPO_ORG="${CICD_REPO_ORG:-RedHatInsights}"
 export ENABLE_TELEMETRY="true"
 SUPPORTED_CLUSTERS=('ephemeral' 'crcd')
 if [[ -z "${AVAILABLE_CLUSTERS[*]}" ]]; then
@@ -62,10 +60,8 @@ if [ -n "$gitlabMergeRequestIid" ]; then
   export IMAGE_TAG="pr-${gitlabMergeRequestIid}-${IMAGE_TAG}"
 fi
 
-
 export GIT_COMMIT=$(git rev-parse HEAD)
-export ARTIFACTS_DIR="$WORKSPACE/artifacts"
-
+export ARTIFACTS_DIR="${APP_ROOT}/artifacts"
 rm -rf "$ARTIFACTS_DIR" && mkdir -p "$ARTIFACTS_DIR"
 
 # TODO: create custom jenkins agent image that has a lot of this stuff pre-installed
@@ -79,17 +75,16 @@ python3 -m pip install --upgrade pip 'setuptools<58' wheel
 python3 -m pip install --upgrade 'crc-bonfire>=4.10.4'
 
 # clone repo to download cicd scripts
-rm -rf "$BONFIRE_ROOT"
-echo "Fetching branch '$BONFIRE_REPO_BRANCH' of https://github.com/${BONFIRE_REPO_ORG}/cicd-tools.git"
-git clone --branch "$BONFIRE_REPO_BRANCH" "https://github.com/${BONFIRE_REPO_ORG}/cicd-tools.git" "$BONFIRE_ROOT"
+echo "Fetching branch '$CICD_REPO_BRANCH' of https://github.com/${CICD_REPO_ORG}/cicd-tools.git"
+git clone --branch "$CICD_REPO_BRANCH" "https://github.com/${CICD_REPO_ORG}/cicd-tools.git" "$CICD_TOOLS_DIR"
 
 # Do a docker login to ensure our later 'docker pull' calls have an auth file created
-source "${CICD_ROOT}/_common_container_logic.sh"
+source "${CICD_TOOLS_DIR}/_common_container_logic.sh"
 login
 
 # Gives access to helper commands such as "oc_wrapper"
 add_cicd_bin_to_path() {
-  if ! command -v oc_wrapper; then export PATH=$PATH:${CICD_ROOT}/bin; fi
+  if ! command -v oc_wrapper; then export PATH=$PATH:${CICD_TOOLS_DIR}/bin; fi
 }
 
 try_login_openshift_cluster() {

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@
 CMD_OPTS="-t ${IMAGE}:${IMAGE_TAG}"
 set -e
 
-source ${CICD_ROOT}/_common_container_logic.sh
+source "${CICD_TOOLS_DIR}/_common_container_logic.sh"
 
 is_pr_or_mr_build() {
     [ -n "$ghprbPullId" ] || [ -n "$gitlabMergeRequestId" ]

--- a/deploy_ephemeral_db.sh
+++ b/deploy_ephemeral_db.sh
@@ -1,7 +1,7 @@
 # Reserve a namespace, deploy your app without dependencies just to get a DB set up
 # Stores database env vars
 
-source ${CICD_ROOT}/_common_deploy_logic.sh
+source ${CICD_TOOLS_DIR}/_common_deploy_logic.sh
 
 # the db that the unit test relies on can be set before 'source'ing this script via
 # DB_DEPLOYMENT_NAME -- by default it is '<ClowdApp name>-db'

--- a/deploy_ephemeral_env.sh
+++ b/deploy_ephemeral_env.sh
@@ -1,4 +1,4 @@
-source ${CICD_ROOT}/_common_deploy_logic.sh
+source ${CICD_TOOLS_DIR}/_common_deploy_logic.sh
 
 # Caller can define any extra deploy arguments to be passed to bonfire
 : ${EXTRA_DEPLOY_ARGS:=""}

--- a/examples/backend-pipeline-pr-checks/Jenkinsfile
+++ b/examples/backend-pipeline-pr-checks/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
                 withVault([configuration: configuration, vaultSecrets: secrets]) {
                     sh './build_deploy.sh'
                 }
-                
+
                 sh 'mkdir -p artifacts'
             }
         }
@@ -58,24 +58,29 @@ pipeline {
                         withVault([configuration: configuration, vaultSecrets: secrets]) {
                             sh '''
                                 curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh
-                                
+
                                 source ./.cicd_bootstrap.sh
-                                source "${CICD_ROOT}/deploy_ephemeral_env.sh"
-                                source "${CICD_ROOT}/cji_smoke_test.sh"
+                                source "${CICD_TOOLS_DIR}/deploy_ephemeral_env.sh"
+                                source "${CICD_TOOLS_DIR}/cji_smoke_test.sh"
                             '''
                         }
 
                     }
                 }
-                
+
                 stage ('Run vulnerability tests') {
-                    if (env.RUN_PLATSEC == true)
+                    if (env.RUN_PLATSEC == true) {
                         steps {
                             withVault([configuration, vaultSecrets: secrets]) {
-                                sh 'source ${CICD_ROOT}/platsec.sh "$IMAGE" "$ARTIFACTS_DIR"' 
+                                sh '''
+                                    curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh
+                                    source ./.cicd_bootstrap.sh
+                                    source ${CICD_TOOLS_DIR}/platsec.sh "$IMAGE" "$ARTIFACTS_DIR"'
+                                '''
+                            }
                         }
                     }
-                }   
+                }
             }
         }
     }
@@ -87,7 +92,7 @@ pipeline {
                     curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh
                     source ./.cicd_bootstrap.sh
 
-                    source "${CICD_ROOT}/post_test_results.sh"
+                    source "${CICD_TOOLS_DIR}/post_test_results.sh"
                 '''
             }
         }

--- a/examples/frontends-pipeline-pr-checks/iqe_tests.sh
+++ b/examples/frontends-pipeline-pr-checks/iqe_tests.sh
@@ -8,11 +8,11 @@ source ./.cicd_bootstrap.sh
 GIT_COMMIT="master"
 IMAGE_TAG="latest"
 
-source $CICD_ROOT/deploy_ephemeral_env.sh
-source $CICD_ROOT/cji_smoke_test.sh
+source $CICD_TOOLS_DIR/deploy_ephemeral_env.sh
+source $CICD_TOOLS_DIR/cji_smoke_test.sh
 
-mkdir -p $WORKSPACE/artifacts
-cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+mkdir artifacts
+cat << EOF > artifacts/junit-dummy.xml
 <testsuite tests="1">
     <testcase classname="dummy" name="dummytest"/>
 </testsuite>

--- a/examples/pr_check_template.sh
+++ b/examples/pr_check_template.sh
@@ -22,7 +22,7 @@ curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 # The contents of build.sh can be found at:
 # https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/build.sh
 # This script is used to build the image that is used in the PR Check
-source $CICD_ROOT/build.sh
+source $CICD_TOOLS_DIR/build.sh
 
 # Your APP's unit tests should be run in the unit_test.sh script.  Two different
 # examples of unit_test.sh are provided in:
@@ -41,7 +41,7 @@ source $APP_ROOT/unit_test.sh
 # This script is used to deploy the ephemeral environment for smoke tests.
 # The manual steps for this can be found in:
 # https://internal.cloud.redhat.com/docs/devprod/ephemeral/02-deploying/
-source $CICD_ROOT/deploy_ephemeral_env.sh
+source $CICD_TOOLS_DIR/deploy_ephemeral_env.sh
 
 # (DEPRECATED!) Run smoke tests using smoke_test.sh
 #
@@ -50,14 +50,14 @@ source $CICD_ROOT/deploy_ephemeral_env.sh
 # This script is used to run the smoke tests for a given APP.  The ENV VARs are
 # defined at the top in the "Options that must be configured by app owner" section
 # will control the behavior of the test.
-#source $CICD_ROOT/smoke_test.sh
+#source $CICD_TOOLS_DIR/smoke_test.sh
 
 # Run smoke tests using a ClowdJobInvocation (preferred)
 # The contents of this script can be found at:
 # https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/cji_smoke_test.sh
-source $CICD_ROOT/cji_smoke_test.sh
+source $CICD_TOOLS_DIR/cji_smoke_test.sh
 
 # Post a comment with test run IDs to the PR
 # The contents of this script can be found at:
 # https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/post_test_results.sh
-source $CICD_ROOT/post_test_results.sh
+source $CICD_TOOLS_DIR/post_test_results.sh

--- a/examples/unit_test_example_ephemeral_db.sh
+++ b/examples/unit_test_example_ephemeral_db.sh
@@ -1,7 +1,7 @@
 # This script is used to deploy an ephemeral DB for your unit tests run against
 # This script can be found at:
 # https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/deploy_ephemeral_db.sh
-source $CICD_ROOT/deploy_ephemeral_db.sh
+source $CICD_TOOLS_DIR/deploy_ephemeral_db.sh
 
 # Here we remap env vars set by `deploy_ephemeral_db.sh`.  APPs call the DB ENV VARs
 # different names, if your env vars do not match what the shell script sets,

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -25,14 +25,14 @@ fi
 oc_wrapper policy -n $NAMESPACE add-role-to-user edit system:serviceaccount:$NAMESPACE:iqe
 oc_wrapper secrets -n $NAMESPACE link iqe quay-cloudservices-pull --for=pull,mount
 
-python $CICD_ROOT/iqe_pod/create_iqe_pod.py $NAMESPACE \
+python $CICD_TOOLS_DIR/iqe_pod/create_iqe_pod.py $NAMESPACE \
     -e IQE_PLUGINS="$IQE_PLUGINS" \
     -e IQE_MARKER_EXPRESSION="$IQE_MARKER_EXPRESSION" \
     -e IQE_FILTER_EXPRESSION="$IQE_FILTER_EXPRESSION" \
     -e ENV_FOR_DYNACONF=smoke \
     -e NAMESPACE=$NAMESPACE
 
-oc_wrapper cp -n $NAMESPACE $CICD_ROOT/iqe_pod/iqe_runner.sh $IQE_POD_NAME:/iqe_venv/iqe_runner.sh
+oc_wrapper cp -n $NAMESPACE $CICD_TOOLS_DIR/iqe_pod/iqe_runner.sh $IQE_POD_NAME:/iqe_venv/iqe_runner.sh
 oc_wrapper exec $IQE_POD_NAME -n $NAMESPACE -- bash /iqe_venv/iqe_runner.sh
 
 oc_wrapper cp -n $NAMESPACE $IQE_POD_NAME:artifacts/ $ARTIFACTS_DIR


### PR DESCRIPTION
This PR aims to refactor the usage of different variables for relative working dir paths 

- Uses APP_ROOT as WORKSPACE when defined, else current working directy
- Removes  explicit use of WORKSPACE 
- Removes BONFIRE_ROOT, CICD_ROOT, replaces with CICD_TOOLS_DIR

