### PR TITLE
fix(python): fixes python3 and pip3 installation

### DIFF
--- a/image_build_scripts/install_system_dependencies.sh
+++ b/image_build_scripts/install_system_dependencies.sh
@@ -2,7 +2,7 @@
 
 dependencies=(
     "python3.11"
-    "python3-pip"
+    "python3.11-pip"
     "shadow-utils"
     "tar"
     "gzip"
@@ -10,3 +10,6 @@ dependencies=(
 
 microdnf install -y "${dependencies[@]}"
 microdnf clean all
+
+alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.11 1


### PR DESCRIPTION
`pip3` is 3.9 version, which was also installing Python 3.9.

This installs the correct `pip` version, and configures `python3` and `pip3` links for the Python `3.11` version. 

