### PR TITLE
feat: add flag to control IMAGE_TAG overwrite behavior

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -64,7 +64,7 @@ export WORKSPACE=${WORKSPACE:-$APP_ROOT}  # if running in jenkins, use the build
 export BONFIRE_ROOT=${TMP_JOB_DIR}/.bonfire
 export CICD_ROOT=${BONFIRE_ROOT}
 
-if [[ -z "$IMAGE_TAG" ]]; then
+if [[ -z "$IMAGE_TAG" ]] || [[ -z "$PRESERVE_IMAGE_TAG" ]]; then
     export IMAGE_TAG=$(get_image_tag)
 fi
 

--- a/frontends/Jenkinsfile
+++ b/frontends/Jenkinsfile
@@ -26,11 +26,9 @@ pipeline {
     environment {
         NODE_BASE_IMAGE="registry.access.redhat.com/ubi9/nodejs-18:1-53"
         CYPRESS_TEST_IMAGE="quay.io/cloudservices/cypress-e2e-image:06b70f3"
-
         CICD_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main"
-
         IMAGE="${APP_IMAGE}"
-
+        PRESERVE_IMAGE_TAG="true"
     }
 
     stages {


### PR DESCRIPTION
- this PR adds a flag to control whether if IMAGE_TAG  gets forcibly set or not. 
- Now the original behavior is restored, and `IMAGE_TAG` will be always set by the `bootsrap.sh` script. 
- One can avoid this behavior and set `PRESERVE_IMAGE_TAG` to a non empty value to keep the pre-existing `IMAGE_TAG` value.
- this is to avoid regressions after #19 was merged, where this behavior was changed to force the `IMAGE_TAG` preservation if it was already defined.