### PR TITLE
[WIP] Do not re-pull the mc image, use 'bridge' network instead of 'host'

### DIFF
--- a/cji_smoke_test.sh
+++ b/cji_smoke_test.sh
@@ -162,9 +162,10 @@ mc --no-color --quiet mirror --overwrite minio/${BUCKET_NAME} /artifacts/
 "
 
 run_mc () {
-    echo "running: docker run -t --net=host --name=$CONTAINER_NAME --entrypoint=\"/bin/sh\" $MC_IMAGE -c \"$CMD\""
+    # image was already pulled earlier in this script, use --pull=never
+    echo "running: docker run -t --net=bridge --pull=never --name=$CONTAINER_NAME --entrypoint=\"/bin/sh\" $MC_IMAGE -c \"$CMD\""
     set +e
-    docker run -t --net=host --name=$CONTAINER_NAME --entrypoint="/bin/sh" $MC_IMAGE -c "$CMD"
+    docker run -t --net=bridge --pull=never --name=$CONTAINER_NAME --entrypoint="/bin/sh" $MC_IMAGE -c "$CMD"
     RET_CODE=$?
     docker cp $CONTAINER_NAME:/artifacts/. $ARTIFACTS_DIR
     docker rm $CONTAINER_NAME

--- a/cji_smoke_test.sh
+++ b/cji_smoke_test.sh
@@ -165,9 +165,9 @@ mc --no-color --quiet mirror --overwrite minio/${BUCKET_NAME} /artifacts/
 run_mc () {
     echo "DOCKER_CONFIG: ${DOCKER_CONFIG}"
     # image was already pulled earlier in this script, use --pull=never
-    echo "running: docker run -t --net=bridge --pull=never --name=$CONTAINER_NAME --entrypoint=\"/bin/sh\" $MC_IMAGE -c \"$CMD\""
+    echo "running: docker run -t --net=host --pull=never --name=$CONTAINER_NAME --entrypoint=\"/bin/sh\" $MC_IMAGE -c \"$CMD\""
     set +e
-    docker run -t --net=bridge --pull=never --name=$CONTAINER_NAME --entrypoint="/bin/sh" $MC_IMAGE -c "$CMD"
+    docker run -t --net=host --pull=never --name=$CONTAINER_NAME --entrypoint="/bin/sh" $MC_IMAGE -c "$CMD"
     RET_CODE=$?
     docker cp $CONTAINER_NAME:/artifacts/. $ARTIFACTS_DIR
     docker rm $CONTAINER_NAME

--- a/cji_smoke_test.sh
+++ b/cji_smoke_test.sh
@@ -52,6 +52,7 @@ else
 fi
 
 # minio client is used to fetch test artifacts from minio in the ephemeral ns
+echo "DOCKER_CONFIG: ${DOCKER_CONFIG}"
 echo "Running: docker pull ${MC_IMAGE}"
 docker pull ${MC_IMAGE}
 
@@ -162,6 +163,7 @@ mc --no-color --quiet mirror --overwrite minio/${BUCKET_NAME} /artifacts/
 "
 
 run_mc () {
+    echo "DOCKER_CONFIG: ${DOCKER_CONFIG}"
     # image was already pulled earlier in this script, use --pull=never
     echo "running: docker run -t --net=bridge --pull=never --name=$CONTAINER_NAME --entrypoint=\"/bin/sh\" $MC_IMAGE -c \"$CMD\""
     set +e


### PR DESCRIPTION
We intermittently see that the 'docker pull' works but the 'docker run' using the same image later fails. Trying '--pull never' to see if that prevents the issue from popping up.