### PR TITLE
Set REGISTRY_AUTH_FILE env var

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -83,6 +83,7 @@ set -x
 
 # Set up docker cfg
 export DOCKER_CONFIG="${TMP_JOB_DIR}/.docker"
+export REGISTRY_AUTH_FILE="${DOCKER_CONFIG}/config.json"
 mkdir "$DOCKER_CONFIG"
 
 # Set up kube cfg

--- a/frontends/cypress_component_tests.sh
+++ b/frontends/cypress_component_tests.sh
@@ -12,6 +12,7 @@ echo "job tmp dir location: $TMP_JOB_DIR"
 
 # Set up docker cfg
 export DOCKER_CONFIG="${TMP_JOB_DIR}/.docker"
+export REGISTRY_AUTH_FILE="${DOCKER_CONFIG}/config.json"
 mkdir "$DOCKER_CONFIG"
 
 docker login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io

--- a/frontends/cypress_e2e_tests.sh
+++ b/frontends/cypress_e2e_tests.sh
@@ -14,6 +14,8 @@ echo "job tmp dir location: $TMP_JOB_DIR"
 
 # Set up docker cfg
 export DOCKER_CONFIG="${TMP_JOB_DIR}/.docker"
+export REGISTRY_AUTH_FILE="${DOCKER_CONFIG}/config.json"
+
 mkdir "$DOCKER_CONFIG"
 
 docker login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io

--- a/src/shared/image_builder.sh
+++ b/src/shared/image_builder.sh
@@ -273,7 +273,10 @@ cicd::image_builder::_try_log_in_to_image_registries() {
   if ! cicd::image_builder::local_build; then
     DOCKER_CONFIG="$(mktemp -d -p "$HOME")"
     export DOCKER_CONFIG
-    echo -n '{}' >"${DOCKER_CONFIG}/config.json"
+    REGISTRY_AUTH_FILE="${DOCKER_CONFIG}/config.json"
+    export REGISTRY_AUTH_FILE
+
+    echo -n '{}' > "${REGISTRY_AUTH_FILE}"
   fi
 
   if cicd::image_builder::_quay_credentials_found; then

--- a/test/shared_image_builder.bats
+++ b/test/shared_image_builder.bats
@@ -599,20 +599,25 @@ teardown() {
 @test "Image build setup doesn't force fresh DOCKER_CONF if not in CI context" {
 
     unset DOCKER_CONFIG
+    unset REGISTRY_AUTH_FILE
     unset CI
 
     source load_module.sh image_builder
     assert [ -z "$DOCKER_CONFIG" ]
+    assert [ -z "$REGISTRY_AUTH_FILE" ]
 }
 
 @test "build on CI forces fresh DOCKER_CONF creds in CI context" {
 
     CI="true"
     unset DOCKER_CONFIG
+    unset REGISTRY_AUTH_FILE
 
     source load_module.sh image_builder
     assert [ -n "$DOCKER_CONFIG" ]
     assert [ -w "${DOCKER_CONFIG}/config.json" ]
+    assert [ -n "$REGISTRY_AUTH_FILE" ]
+    assert [ -w "${REGISTRY_AUTH_FILE}" ]
 }
 
 @test "Default image tag is configured if none set" {


### PR DESCRIPTION
So that if any tool has set it before our jobs begin, it will be overwritten and match DOCKER_CONFIG