### PR TITLE
Fix gitlab merge request id usage

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -39,7 +39,7 @@ get_image_tag() {
 }
 
 is_change_request() {
-  [ -n "$ghprbPullId" ] || [ -n "$gitlabMergeRequestId" ]
+  [ -n "$ghprbPullId" ] || [ -n "$gitlabMergeRequestIid" ]
 }
 
 get_change_request_id() {
@@ -50,8 +50,8 @@ get_change_request_id() {
         change_id="$ghprbPullId"
     fi
 
-    if [[ -n "$gitlabMergeRequestId" ]]; then
-        change_id="$gitlabMergeRequestId"
+    if [[ -n "$gitlabMergeRequestIid" ]]; then
+        change_id="$gitlabMergeRequestIid"
     fi
 
     echo "$change_id"

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ set -e
 source ${CICD_ROOT}/_common_container_logic.sh
 
 is_pr_or_mr_build() {
-    [ -n "$ghprbPullId" ] || [ -n "$gitlabMergeRequestId" ]
+    [ -n "$ghprbPullId" ] || [ -n "$gitlabMergeRequestIid" ]
 }
 
 is_rhel7_host() {

--- a/src/shared/image_builder.sh
+++ b/src/shared/image_builder.sh
@@ -149,7 +149,7 @@ cicd::image_builder::_get_context_based_image_tag() {
 }
 
 cicd::image_builder::is_change_request_context() {
-  [ -n "$ghprbPullId" ] || [ -n "$gitlabMergeRequestId" ]
+  [ -n "$ghprbPullId" ] || [ -n "$gitlabMergeRequestIid" ]
 }
 
 cicd::image_builder::get_build_id() {
@@ -158,8 +158,8 @@ cicd::image_builder::get_build_id() {
 
   if [ -n "$ghprbPullId" ]; then
     build_id="$ghprbPullId"
-  elif [ -n "$gitlabMergeRequestId" ]; then
-    build_id="$gitlabMergeRequestId"
+  elif [ -n "$gitlabMergeRequestIid" ]; then
+    build_id="$gitlabMergeRequestIid"
   fi
 
   echo -n "$build_id"

--- a/test/shared_image_builder.bats
+++ b/test/shared_image_builder.bats
@@ -110,7 +110,7 @@ teardown() {
         echo "1abcdef"
     }
 
-    gitlabMergeRequestId=4321
+    gitlabMergeRequestIid=4321
 
     source load_module.sh image_builder
 


### PR DESCRIPTION
Hi! This PR changes the usage of `gitlabMergeRequestId` to `gitlabMergeRequestIid`. I've been seeing failures in the `runtimes-inventory` jenkins pipeline, and I've narrowed it down to the failure to: https://github.com/RedHatInsights/cicd-tools/blob/main/bootstrap.sh#L33

From taking a look through the gitlab api and jenkins gitlab plugin documention, it appears that Id is not the same as Iid. If we're looking for the id of a specific merge request to use in an image tag for example like pr-215-5ff8174, the 215 here is the Iid. The id looks to refer to a more global merge request Id, while the Iid is Internal ID for the merge request. This PR changes the Id usage in this repo to use Iid instead.

In the `runtimes-inventory` pipeline we have two images that need to be built, `insights-rbi-events` and `insights-rbi-rest`. For running the bonfire & ephemeral step of the pipeline, I have the IMAGE variable set to the events image (and set up an IMAGE_TAG variable to contain our image tag), and then set the rest image into the EXTRA_DEPLOY_ARGS as `--set-image-tag quay.io/cloudservices/insights-rbi-rest=${IMAGE_TAG}`. What I'm seeing is that the image tag on the events image is being overwritten by one that uses an id, but because I have placed my rest image information in the extra args it is untouched by the bootstrap script. So what I see is:

```
15:50:38 [2024-08-20T19:50:38.418Z] ++ bonfire deploy runtimes-inventory --source=appsre --ref-env insights-production --set-image-tag quay.io/cloudservices/insights-rbi-events=pr-1392946-5ff8174 --namespace ephemeral-zt5mhq --timeout 2700 --optional-deps-method hybrid --frontends false --set-template-ref runtimes-inventory=5ff8174921ec988d9eac2471e995244fff2fa641 --set-image-tag quay.io/cloudservices/insights-rbi-rest=pr-215-5ff8174
```
where I'm expecting an image tag of `pr-215-5ff8174`, but the events image is being changed to `pr-1392946-5ff8174`. Which causes failures trying to deploy this into Ephemeral, and our pipeline fails.
