### PR TITLE
Use docker search instead of manifest inspect to check for tagged IQE images

### DIFF
--- a/cji_smoke_test.sh
+++ b/cji_smoke_test.sh
@@ -88,7 +88,7 @@ fi
 
 if [ ! -z "$IQE_IMAGE_TAG_TMP" ]; then
     set +e
-    if docker manifest inspect quay.io/cloudservices/iqe-tests:"$IQE_IMAGE_TAG_TMP"; then
+    if docker search quay.io/cloudservices/iqe-tests --list-tags --limit 5000 | grep -e "$IQE_IMAGE_TAG_TMP"; then
         echo "Found IQE_IMAGE_TAG=$IQE_IMAGE_TAG_TMP. It will be used for testing."
         export IQE_IMAGE_TAG="$IQE_IMAGE_TAG_TMP"
     fi


### PR DESCRIPTION
The docker inspect command was errored out when trying to inspect IQE tagged images.I think the more appropriate way would be just to check the tags and see if the IQE tagged image is present. 

Error:

```
podman manifest inspect quay.io/cloudservices/iqe-tests:rhsm-subscriptions-pr-3554 -v
Error: getting content of manifest list or image quay.io/cloudservices/iqe-tests:rhsm-subscriptions-pr-3554: parsing manifest blob "{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\",\"config\":{\"mediaType\":\"application/vnd.oci.image.config.v1+json\",\"digest\":\"sha256:3ec73021fd3583315ff78c5005c9dd6ca1903a8feab0380d63392a3aee293686\",\"size\":12393},\"layers\":[{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:13d626b04f00b85307f9a72d61ba17940ccdeb5e122b7e9354053f94cad4df66\",\"size\":39302012},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:1f0cb7583df5d3d1f622dd3377db330735e05a226e4b4d1b8c1e02be0a2ef425\",\"size\":293292199},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:33753ec897138df608b3824a07466a137d365e8794e24502f28e7f8d80771056\",\"size\":212081223},{\"mediaType\":\"application/vnd.oci.image.layer.v1.tar+gzip\",\"digest\":\"sha256:4e01a258e3fe7d7afe866d7e5f99886271737808795b2c641a95d79890b303f2\",\"size\":5182892}],\"annotations\":{\"org.opencontainers.image.base.digest\":\"sha256:58da916c8a499810cb2c08f3dcdca7f6d4ba25c16efe75afe69c139180dc9abc\",\"org.opencontainers.image.base.name\":\"quay.io/cloudservices/iqe-tests:rhsm-subscriptions\"}}" as a "application/vnd.oci.image.manifest.v1+json": Treating single images as manifest lists is not implemented
```

Test job: https://ci.ext.devshift.net/job/RedHatInsights-rhsm-subscriptions-pr-check/8134/consoleFull