### PR TITLE
fix: update docker/podman cp . syntax for newer version.

### DIFF
--- a/frontends/lint.sh
+++ b/frontends/lint.sh
@@ -8,7 +8,7 @@ trap_proxy teardown EXIT ERR SIGINT SIGTERM
 
 docker run --name $TEST_CONT -d -i --rm $NODE_BASE_IMAGE /bin/sh
 
-docker cp . "${TEST_CONT}:/opt/app-root/src/"
+docker cp ./. "${TEST_CONT}:/opt/app-root/src/"
 
 docker exec -i -w "/opt/app-root/src/" $TEST_CONT sh -c "npm i"
 docker exec -i -w "/opt/app-root/src/" $TEST_CONT sh -c "npm run ci:lint"


### PR DESCRIPTION
`docker/podman cp .` is copying the parent directory as well as the contents of the current directory.  The scripts are only expecting the contents of the current directory.  Switching it to `docker cp . `.

curiousity-frontend is using these scripts.