### PR TITLE
fix(RHINENG-22495): Use --set-image-tag instead of --set-parameter in Konflux script

### DIFF
--- a/konflux_scripts/parse-snapshot.py
+++ b/konflux_scripts/parse-snapshot.py
@@ -193,8 +193,8 @@ def _add_component_to_params(params: list[str], component_name: str, snapshot_co
         f"{component_name}={snapshot_component.source.git.revision}",
         "--set-parameter",
         f"{component_name}/IMAGE={snapshot_component.container_image.image}@sha256",
-        "--set-parameter",
-        f"{component_name}/IMAGE_TAG={snapshot_component.container_image.sha}"
+        "--set-image-tag",
+        f"{snapshot_component.container_image.image}@sha256={snapshot_component.container_image.sha}"
     ))
 
 if __name__ == "__main__":


### PR DESCRIPTION
Using `--set-parameter host-inventory/IMAGE_TAG` instead of `--set-image-tag ...` prevents HBI from running `run-db-migration` job when deploying in Konflux pipelines. Here is more detailed description of the issue: https://redhat-internal.slack.com/archives/C07FQ00BJV8/p1774348601593979