### PR TITLE
Add Playwright container support to IQE CJI scripts

### DIFF
--- a/cji_smoke_test.sh
+++ b/cji_smoke_test.sh
@@ -13,6 +13,7 @@
 #IQE_PLUGINS="plugin1,plugin2" -- IQE plugins to run tests for, leave unset to use ClowdApp's iqePlugin value
 #IQE_ENV="something" -- value to set for ENV_FOR_DYNACONF, default is "clowder_smoke"
 #IQE_SELENIUM="true" -- whether to run IQE pod with a selenium container, default is "false"
+#IQE_PLAYWRIGHT="true" -- whether to run IQE pod with a playwright container, default is "false"
 #IQE_RP_ARGS=True -- Turn on reporting to reportportal
 #IQE_IBUTSU_SOURCE="post_stage" -- update the ibutsu source for the current run
 #IQE_ENV_VARS="ENV_VAR1=value1,ENV_VAR2=value2" -- custom set of extra environment variables to set on IQE pod
@@ -35,6 +36,7 @@ set -e
 : "${IQE_PLUGINS:='""'}"
 : "${IQE_ENV:=clowder_smoke}"
 : "${IQE_SELENIUM:=false}"
+: "${IQE_PLAYWRIGHT:=false}"
 : "${IQE_PARALLEL_ENABLED:='""'}"
 : "${IQE_PARALLEL_WORKER_COUNT:='""'}"
 : "${IQE_RP_ARGS:='""'}"
@@ -61,6 +63,11 @@ fi
 SELENIUM_ARG=""
 if [ "$IQE_SELENIUM" = "true" ]; then
     SELENIUM_ARG=" --selenium "
+fi
+
+PLAYWRIGHT_ARG=""
+if [ "$IQE_PLAYWRIGHT" = "true" ]; then
+    PLAYWRIGHT_ARG=" --playwright "
 fi
 
 ENV_VAR_ARGS=""
@@ -105,6 +112,7 @@ POD=$(
     --env "$IQE_ENV" \
     --cji-name $CJI_NAME \
     $SELENIUM_ARG \
+    $PLAYWRIGHT_ARG \
     --parallel-enabled $IQE_PARALLEL_ENABLED \
     --parallel-worker-count $IQE_PARALLEL_WORKER_COUNT \
     --rp-args $IQE_RP_ARGS \

--- a/konflux_scripts/deploy-iqe-cji.sh
+++ b/konflux_scripts/deploy-iqe-cji.sh
@@ -18,6 +18,7 @@ main() {
 
     # Optional arguments
     local selenium="${IQE_SELENIUM:-false}"
+    local playwright="${IQE_PLAYWRIGHT:-false}"
     local iqe_marker_expression="${IQE_MARKER_EXPRESSION}"
     local iqe_filter_expression="${IQE_FILTER_EXPRESSION}"
     local iqe_image_tag="${IQE_IMAGE_TAG}"
@@ -35,6 +36,11 @@ main() {
     local selenium_arg=""
     if [[ "$selenium" == "true" ]]; then
         selenium_arg="--selenium"
+    fi
+
+    local playwright_arg=""
+    if [[ "$playwright" == "true" ]]; then
+        playwright_arg="--playwright"
     fi
 
     iqe_env_var_args=$(awk -v IQE_ENV_VARS="$iqe_env_vars" 'BEGIN {
@@ -59,6 +65,7 @@ main() {
     --cji-name "$cji_name" \
     --parallel-enabled "$iqe_parallel_enabled" \
     $selenium_arg \
+    $playwright_arg \
     $iqe_env_var_args \
     --namespace "$ns")
 


### PR DESCRIPTION
Add IQE_PLAYWRIGHT environment variable support to enable Playwright container deployment in IQE test runs, following the same pattern as existing IQE_SELENIUM support.

Changes:
- cji_smoke_test.sh: Add IQE_PLAYWRIGHT env var handling, convert to --playwright flag for bonfire deploy-iqe-cji command
- konflux_scripts/deploy-iqe-cji.sh: Add IQE_PLAYWRIGHT env var handling, convert to --playwright flag for bonfire deploy-iqe-cji command

Both scripts now read IQE_PLAYWRIGHT environment variable and pass --playwright flag to bonfire when set to "true".

Enables Tekton pipelines to deploy IQE tests with Playwright containers for UI testing alongside or instead of Selenium.