### PR TITLE
fix: crc-bonfire installation on python dependencies script

### DIFF
--- a/image_build_scripts/install_python_dependencies.sh
+++ b/image_build_scripts/install_python_dependencies.sh
@@ -3,7 +3,7 @@ set -e
 
 dependencies=(
     "awscli==1.29.28"
-    "crc-bonfire"
+    "crc-bonfire[cli]"
     "pydantic"
 )
 


### PR DESCRIPTION
Fix Python dependencies install script