### PR TITLE
Remove trace logging for Copying files to S3

### DIFF
--- a/konflux_scripts/upload-to-s3.sh
+++ b/konflux_scripts/upload-to-s3.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 main() {
 


### PR DESCRIPTION
The variables for the aws key should not be revealed.

They were revealed in a konflux pipeline using bonfire and iqe.  The following configuration was set:
```
Repo: https://github.com/RedHatInsights/bonfire-tekton.git
pathInRepo: pipelines/basic.yaml
```

This commit removes the trace logging.