### PR TITLE
feat(konflux): custom CJI templates and IBUTSU_MODE in deploy-iqe-cji

### DIFF
--- a/cji_smoke_test.sh
+++ b/cji_smoke_test.sh
@@ -16,6 +16,8 @@
 #IQE_PLAYWRIGHT="true" -- whether to run IQE pod with a playwright container, default is "false"
 #IQE_RP_ARGS=True -- Turn on reporting to reportportal
 #IQE_IBUTSU_SOURCE="post_stage" -- update the ibutsu source for the current run
+#IBUTSU_MODE="s3" -- Ibutsu upload mode passed to bonfire --env-var IBUTSU_MODE
+#IQE_CJI_TEMPLATE="/path/to/template.yaml" -- custom CJI OpenShift template (bonfire --template-file)
 #IQE_ENV_VARS="ENV_VAR1=value1,ENV_VAR2=value2" -- custom set of extra environment variables to set on IQE pod
 #NAMESPACE="mynamespace" -- namespace to deploy iqe pod into, usually already set by 'deploy_ephemeral_env.sh'
 

--- a/konflux_scripts/deploy-iqe-cji.sh
+++ b/konflux_scripts/deploy-iqe-cji.sh
@@ -27,11 +27,14 @@ main() {
     local iqe_test_importance="${IQE_TEST_IMPORTANCE}"
     local iqe_plugins="${IQE_PLUGINS}"
     local iqe_env="${IQE_ENV:-clowder_smoke}"
-    #iqe_env_vars="ENV_VAR1=value1,ENV_VAR2=value2" -- custom set of extra environment variables to set on IQE pod
-    local iqe_env_vars="${IQE_ENV_VARS}"
+    # IQE_ENV_VARS="ENV_VAR1=value1,ENV_VAR2=value2" -- extra env vars for the IQE pod (bonfire --env-var)
+    local iqe_env_vars="${IQE_ENV_VARS:-}"
     local iqe_cji_timeout="${IQE_CJI_TIMEOUT:-10m}"
-    local iqe_env_vars="${IQE_ENV_VARS:=}"
     local iqe_parallel_enabled="${IQE_PARALLEL_ENABLED}"
+    local iqe_rp_args="${IQE_RP_ARGS:-}"
+    local iqe_cji_template="${IQE_CJI_TEMPLATE:-}"
+    local ibutsu_mode="${IBUTSU_MODE:-}"
+    local ibutsu_source="${IQE_IBUTSU_SOURCE:-${IBUTSU_SOURCE:-}}"
 
     local selenium_arg=""
     if [[ "$selenium" == "true" ]]; then
@@ -50,6 +53,24 @@ main() {
       }
     }')
 
+    template_file_arg=""
+    if [[ -n "$iqe_cji_template" ]]; then
+        if [[ ! -f "$iqe_cji_template" ]]; then
+            echo "ERROR: IQE_CJI_TEMPLATE is set but file does not exist: ${iqe_cji_template}"
+            exit 1
+        fi
+        template_file_arg="--template-file ${iqe_cji_template}"
+    fi
+
+    if [[ -n "$ibutsu_mode" ]]; then
+        iqe_env_var_args+=" --env-var IBUTSU_MODE=${ibutsu_mode}"
+    fi
+
+    ibutsu_source_arg=""
+    if [[ -n "$ibutsu_source" ]]; then
+        ibutsu_source_arg="--ibutsu-source ${ibutsu_source}"
+    fi
+
     export BONFIRE_NS_REQUESTER="$ns_requester"
 
     # Invoke the CJI using the options set via env vars
@@ -64,8 +85,11 @@ main() {
     --env "$iqe_env" \
     --cji-name "$cji_name" \
     --parallel-enabled "$iqe_parallel_enabled" \
+    --rp-args "${iqe_rp_args}" \
     $selenium_arg \
     $playwright_arg \
+    $template_file_arg \
+    $ibutsu_source_arg \
     $iqe_env_var_args \
     --namespace "$ns")
 


### PR DESCRIPTION
## Summary

Ephemeral Konflux IQE runs need Ibutsu S3 uploads (`IBUTSU_MODE=s3`), but the default bonfire CJI template cannot mount `ibutsu-aws-credentials` and `deploy-iqe-cji.sh` had no way to pass a custom template.

## Blockers addressed

- **No `--template-file` support** — teams had to inline `bonfire deploy-iqe-cji` in custom Tekton tasks to mount AWS credentials for S3.
- **S3 mode needs AWS env vars** — `IBUTSU_MODE=s3` requires `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, and `AWS_BUCKET` from `ibutsu-aws-credentials`; the default CJI template only mounts `ibutsu-config` and `iqe-ibutsu-token`.
- **`IBUTSU_MODE` via `IQE_ENV_VARS` is awkward** — add a dedicated `IBUTSU_MODE` env var instead of encoding it in a comma-separated list.

## Changes

- `IQE_CJI_TEMPLATE` → `bonfire deploy-iqe-cji --template-file`
- `IBUTSU_MODE` → `--env-var IBUTSU_MODE=...`
- `IQE_IBUTSU_SOURCE` / `IBUTSU_SOURCE` → `--ibutsu-source`
- `IQE_RP_ARGS` forwarding; fix duplicate `IQE_ENV_VARS` assignment


Made with [Cursor](https://cursor.com)